### PR TITLE
Have Binder badge launch into Jupyter notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 ProbabilisticProgrammingPrimer for [PyData London Meetup 4/9/18](https://www.meetup.com/PyData-London-Meetup/events/254003548/):
 
 - A modern introduction to Hamiltonian Monte Carlo and Bayesian workflows [![Video](https://img.shields.io/badge/watch-YouTube-red.svg)](https://youtu.be/0kRytJZcHVw)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/springcoil/pydataprobprog/master)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/springcoil/pydataprobprog/master?filepath=Bayesian_Workflow.ipynb)


### PR DESCRIPTION
As this repo exists as a standalone support for the PyData meetup talk then it will only have this one notebook, and so the Binder launch badge might as well launch directly into the Jupyter notebook rather then the Jupyter server browser.

@springcoil Sorry I didn't think of having this be in the first PR &mdash; it was late when I submitted it.